### PR TITLE
WIP: Recursive Type support

### DIFF
--- a/Ajuna.SDK.sln
+++ b/Ajuna.SDK.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32802.440
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32319.34
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ajuna.AspNetCore", "Ajuna.AspNetCore\Ajuna.AspNetCore.csproj", "{7177525C-B443-43EE-A319-17C85E0252DB}"
 EndProject

--- a/Ajuna.SDK.sln
+++ b/Ajuna.SDK.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.1.32319.34
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32802.440
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ajuna.AspNetCore", "Ajuna.AspNetCore\Ajuna.AspNetCore.csproj", "{7177525C-B443-43EE-A319-17C85E0252DB}"
 EndProject

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,7 +17,7 @@ set AJUNA_ROOT=D:\Ajuna.SDK
 set LOCAL_NUGET_ROOT=D:\NuGet
 set LOCAL_NUGET_CACHE=%SYSTEMDRIVE%\Users\%USERNAME%\.nuget\packages
 set LOCAL_NUGET_BINARY=nuget.exe
-set AJUNA_VERSION=0.1.21
+set AJUNA_VERSION=0.1.22
 
 cd %AJUNA_ROOT%
 dotnet build --configuration Release

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,7 +17,7 @@ set AJUNA_ROOT=D:\Ajuna.SDK
 set LOCAL_NUGET_ROOT=D:\NuGet
 set LOCAL_NUGET_CACHE=%SYSTEMDRIVE%\Users\%USERNAME%\.nuget\packages
 set LOCAL_NUGET_BINARY=nuget.exe
-set AJUNA_VERSION=0.1.22
+set AJUNA_VERSION=0.1.23
 
 cd %AJUNA_ROOT%
 dotnet build --configuration Release

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Using a terminal of your choice, create a new directory for your project and exe
 ```sh
 dotnet new sln
 dotnet new ajuna \
-   --sdk_version 0.1.22 \
+   --sdk_version 0.1.23 \
    --rest_service AjunaExample.RestService \
    --net_api AjunaExample.NetApiExt \
    --rest_client AjunaExample.RestClient \

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Using a terminal of your choice, create a new directory for your project and exe
 ```sh
 dotnet new sln
 dotnet new ajuna \
-   --sdk_version 0.1.21 \
+   --sdk_version 0.1.22 \
    --rest_service AjunaExample.RestService \
    --net_api AjunaExample.NetApiExt \
    --rest_client AjunaExample.RestClient \

--- a/Tools/Ajuna.DotNet.Template/templates/Ajuna/.template.config/template.json
+++ b/Tools/Ajuna.DotNet.Template/templates/Ajuna/.template.config/template.json
@@ -12,7 +12,7 @@
    "symbols": {
       "sdk_version": {
          "datatype": "string",
-         "defaultValue": "0.1.22",
+         "defaultValue": "0.1.23",
          "description": "Uses the given Ajuna SDK version.",
          "replaces": "AJUNA_SDK_VERSION",
          "type": "parameter"

--- a/Tools/Ajuna.DotNet.Template/templates/Ajuna/.template.config/template.json
+++ b/Tools/Ajuna.DotNet.Template/templates/Ajuna/.template.config/template.json
@@ -12,7 +12,7 @@
    "symbols": {
       "sdk_version": {
          "datatype": "string",
-         "defaultValue": "0.1.21",
+         "defaultValue": "0.1.22",
          "description": "Uses the given Ajuna SDK version.",
          "replaces": "AJUNA_SDK_VERSION",
          "type": "parameter"

--- a/Tools/Ajuna.DotNet/Extensions/ReflectedEndpointExtensions.cs
+++ b/Tools/Ajuna.DotNet/Extensions/ReflectedEndpointExtensions.cs
@@ -225,11 +225,6 @@ namespace Ajuna.DotNet.Extensions
             Attributes = MemberAttributes.Public,
          };
 
-         if (method.Name == "SetNextExternal")
-         {
-            System.Diagnostics.Debugger.Break();
-         }
-
          IReflectedEndpointRequest request = endpoint.GetRequest();
          IReflectedEndpointType defaultReturnType = endpoint.GetResponse().GetSuccessReturnType();
          if (defaultReturnType != null)

--- a/Tools/Ajuna.DotNet/Extensions/ReflectedEndpointExtensions.cs
+++ b/Tools/Ajuna.DotNet/Extensions/ReflectedEndpointExtensions.cs
@@ -76,6 +76,10 @@ namespace Ajuna.DotNet.Extensions
             // Ensure we are importing all model items.
             // Not actually required since we use fully qualified items but we want to get rid of that later.
             currentNamespace.Imports.Add(new CodeNamespaceImport(defaultReturnType.Type.Namespace));
+            foreach (Type genericArgument in defaultReturnType.Type.GenericTypeArguments)
+            {
+               currentNamespace.Imports.Add(new CodeNamespaceImport(genericArgument.Namespace));
+            }
             method.Parameters.Add(new CodeParameterDeclarationExpression(defaultReturnType.Type, "value"));
          }
 
@@ -221,14 +225,22 @@ namespace Ajuna.DotNet.Extensions
             Attributes = MemberAttributes.Public,
          };
 
-         IReflectedEndpointRequest request = endpoint.GetRequest();
+         if (method.Name == "SetNextExternal")
+         {
+            System.Diagnostics.Debugger.Break();
+         }
 
+         IReflectedEndpointRequest request = endpoint.GetRequest();
          IReflectedEndpointType defaultReturnType = endpoint.GetResponse().GetSuccessReturnType();
          if (defaultReturnType != null)
          {
             // Ensure we are importing all model items.
             // Not actually required since we use fully qualified items but we want to get rid of that later.
             clientNamespace.Imports.Add(new CodeNamespaceImport(defaultReturnType.Type.Namespace));
+            foreach (Type genericArgument in defaultReturnType.Type.GenericTypeArguments)
+            { 
+               clientNamespace.Imports.Add(new CodeNamespaceImport(genericArgument.Namespace));
+            }
             method.Parameters.Add(new CodeParameterDeclarationExpression(defaultReturnType.Type, "value"));
          }
 
@@ -313,6 +325,10 @@ namespace Ajuna.DotNet.Extensions
             // Ensure we are importing all model items.
             // Not actually required since we use fully qualified items but we want to get rid of that later.
             clientNamespace.Imports.Add(new CodeNamespaceImport(defaultReturnType.Type.Namespace));
+            foreach (Type genericArgument in defaultReturnType.Type.GenericTypeArguments)
+            {
+               clientNamespace.Imports.Add(new CodeNamespaceImport(genericArgument.Namespace));
+            }
 
             GenerateMockupValueStatement(currentMembers, method, defaultReturnType.Type);
          }

--- a/Tools/Ajuna.DotNet/Extensions/ReflectedEndpointResponseExtensions.cs
+++ b/Tools/Ajuna.DotNet/Extensions/ReflectedEndpointResponseExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Ajuna.DotNet.Client.Interfaces;
+using System;
 using System.CodeDom;
 using System.Collections.Generic;
 using System.Net;
@@ -29,6 +30,10 @@ namespace Ajuna.DotNet.Extensions
          // Ensure we are importing all model items.
          // Not actually required since we use fully qualified items but we want to get rid of that later.
          currentNamespace.Imports.Add(new CodeNamespaceImport(defaultReturnType.Type.Namespace));
+         foreach (Type genericArgument in defaultReturnType.Type.GenericTypeArguments)
+         {
+            currentNamespace.Imports.Add(new CodeNamespaceImport(genericArgument.Namespace));
+         }
 
          return new CodeTypeReference(typeof(Task<>).MakeGenericType(new[] { defaultReturnType.Type }));
       }

--- a/Tools/Ajuna.DotNet/Service/Generators/Base/SolutionGeneratorBase.cs
+++ b/Tools/Ajuna.DotNet/Service/Generators/Base/SolutionGeneratorBase.cs
@@ -44,112 +44,58 @@ namespace Ajuna.DotNet.Service.Generators.Base
       /// <param name="metadata"></param>
       protected abstract void GenerateClasses(MetaData metadata);
 
-      protected Dictionary<uint, (string, List<string>)> GenerateTypes(Dictionary<uint, NodeType> nodeTypes, string basePath, bool write)
+      protected NodeTypeResolver GenerateTypes(Dictionary<uint, NodeType> nodeTypes, string basePath, bool write)
       {
-         var typeDict = new Dictionary<uint, (string, List<string>)>();
+         var resolver = new NodeTypeResolver(NodeRuntime, nodeTypes);
 
-         // TODO (svnscha): Why 10 iterations?
-         int iterations = 10;
-
-         for (int i = 0; i < iterations; i++)
+         foreach (KeyValuePair<uint, NodeTypeResolved> kvp in resolver.TypeNames)
          {
-            for (uint id = 0; id < nodeTypes.Keys.Max(); id++)
+            NodeTypeResolved nodeTypeResolved = kvp.Value;
+            NodeType nodeType = nodeTypeResolved.NodeType;
+
+            switch (nodeType.TypeDef)
             {
-               if (!nodeTypes.TryGetValue(id, out NodeType nodeType) || typeDict.ContainsKey(id))
-               {
-                  continue;
-               }
+               case TypeDefEnum.Composite:
+                  {
+                     var type = nodeType as NodeTypeComposite;
+                     StructBuilder.Init(ProjectName, type.Id, type, resolver)
+                         .Create()
+                         .Build(write: write, out bool success, basePath);
+                     
+                     if (!success)
+                     {
+                        Logger.Error($"Could not build type {type.Id}!");
+                     }
 
-               switch (nodeType.TypeDef)
-               {
-                  case TypeDefEnum.Composite:
-                     {
-                        var type = nodeType as NodeTypeComposite;
-                        (string, List<string>) fullItem = StructBuilder.Init(ProjectName, type.Id, type, typeDict)
-                            .Create()
-                            .Build(write: write, out bool success, basePath);
-                        if (success)
-                        {
-                           typeDict.Add(type.Id, fullItem);
-                        }
+                     break;
+                  }
+               case TypeDefEnum.Variant:
+                  {
+                     var type = nodeType as NodeTypeVariant;
+                     string variantType = GetVariantType(NodeRuntime, string.Join('.', nodeType.Path));
+                     CallVariant(variantType, type, ref resolver, write, basePath);
+                     break;
+                  }
+               case TypeDefEnum.Array:
+                  {
+                     var type = nodeType as NodeTypeArray;
+                     ArrayBuilder.Create(ProjectName, type.Id, type, resolver)
+                         .Create()
+                         .Build(write: write, out bool success, basePath);
 
-                        break;
-                     }
-                  case TypeDefEnum.Variant:
+                     if (!success)
                      {
-                        var type = nodeType as NodeTypeVariant;
-                        string variantType = SolutionGeneratorBase.GetVariantType(NodeRuntime, string.Join('.', nodeType.Path));
-                        CallVariant(variantType, type, ref typeDict, write, basePath);
-                        break;
+                        Logger.Error($"Could not build type {type.Id}!");
                      }
-                  case TypeDefEnum.Sequence:
-                     {
-                        var type = nodeType as NodeTypeSequence;
-                        if (typeDict.TryGetValue(type.TypeId, out (string, List<string>) fullItem))
-                        {
-                           string typeName = $"BaseVec<{fullItem.Item1}>";
-                           typeDict.Add(type.Id, (typeName, fullItem.Item2));
-                        }
 
-                        break;
-                     }
-                  case TypeDefEnum.Array:
-                     {
-                        var type = nodeType as NodeTypeArray;
-                        (string, List<string>) fullItem = ArrayBuilder.Create(ProjectName, type.Id, type, typeDict)
-                            .Create()
-                            .Build(write: write, out bool success, basePath);
-                        if (success)
-                        {
-                           typeDict.Add(type.Id, fullItem);
-                        }
-
-                        break;
-                     }
-                  case TypeDefEnum.Tuple:
-                     {
-                        var type = nodeType as NodeTypeTuple;
-                        SolutionGeneratorBase.CallTuple(type, ref typeDict);
-                        break;
-                     }
-                  case TypeDefEnum.Primitive:
-                     {
-                        var type = nodeType as NodeTypePrimitive;
-                        CallPrimitive(type, ref typeDict);
-                        break;
-                     }
-                  case TypeDefEnum.Compact:
-                     {
-                        var type = nodeType as NodeTypeCompact;
-                        if (typeDict.TryGetValue(type.TypeId, out (string, List<string>) fullItem))
-                        {
-                           string typeName = $"BaseCom<{fullItem.Item1}>";
-                           typeDict.Add(type.Id, (typeName, fullItem.Item2));
-                        }
-
-                        break;
-                     }
-                  case TypeDefEnum.BitSequence:
-                     {
-                        var type = nodeType as NodeTypeBitSequence;
-                        if (typeDict.TryGetValue(type.TypeIdStore, out (string, List<string>) fullItemStore)
-                         && typeDict.TryGetValue(type.TypeIdOrder, out (string, List<string>) fullItemOrder))
-                        {
-                           string typeName = $"BaseBitSeq<{fullItemStore.Item1},{fullItemOrder.Item1}>";
-                           var list = new List<string>();
-                           list.AddRange(fullItemStore.Item2);
-                           list.AddRange(fullItemOrder.Item2);
-                           typeDict.Add(type.Id, (typeName, list));
-                        }
-                        break;
-                     }
-                  default:
-                     throw new NotImplementedException($"Unimplemented enumeration of node type {nodeType.TypeDef}");
-               }
+                     break;
+                  }
+               default:
+                  break; // Handled by type resolver
             }
          }
 
-         return typeDict;
+         return resolver;
       }
 
       private static string GetVariantType(string nodeRunetime, string path)
@@ -189,165 +135,34 @@ namespace Ajuna.DotNet.Service.Generators.Base
          }
       }
 
-      private void CallVariant(string variantType, NodeTypeVariant nodeType, ref Dictionary<uint, (string, List<string>)> typeDict, bool write, string basePath = null)
+      private void CallVariant(string variantType, NodeTypeVariant nodeType, ref NodeTypeResolver typeDict, bool write, string basePath = null)
       {
          switch (variantType)
          {
-            case "Option":
-               {
-                  if (typeDict.TryGetValue(nodeType.Variants[1].TypeFields[0].TypeId, out (string, List<string>) fullItem))
-                  {
-                     typeDict.Add(nodeType.Id, ($"BaseOpt<{fullItem.Item1}>", fullItem.Item2));
-                  }
-
-                  break;
-               }
-
-            case "Result":
-               {
-                  var spaces = new List<string>() { $"Ajuna.NetApi.Model.Types.Base" };
-                  typeDict.Add(nodeType.Id,
-                      ($"BaseTuple<BaseTuple, {ProjectName}.Model.SpRuntime.EnumDispatchError>",
-                          spaces));
-                  break;
-               }
-
-            case "Call":
-               {
-                  (string, List<string>) fullItem = (ProjectName + $".{nodeType.Path[0].MakeMethod()}Call", new List<string>() { ProjectName });
-                  typeDict.Add(nodeType.Id, fullItem);
-                  break;
-               }
-
-            case "Event":
-               {
-                  (string, List<string>) fullItem = (ProjectName + $".{nodeType.Path[0].MakeMethod()}Event", new List<string>() { ProjectName });
-                  typeDict.Add(nodeType.Id, fullItem);
-                  break;
-               }
-
-            case "Error":
-               {
-                  (string, List<string>) fullItem = (ProjectName + $".{nodeType.Path[0].MakeMethod()}Error", new List<string>() { ProjectName });
-                  typeDict.Add(nodeType.Id, fullItem);
-                  break;
-               }
-
             case "Runtime":
                {
-                  (string, List<string>) fullItem = RunetimeBuilder.Init(ProjectName, nodeType.Id, nodeType, typeDict).Create().Build(write: write, out bool success, basePath);
-                  if (success)
+                  RunetimeBuilder.Init(ProjectName, nodeType.Id, nodeType, typeDict).Create().Build(write: write, out bool success, basePath);
+                  if (!success)
                   {
-                     typeDict.Add(nodeType.Id, fullItem);
+                     Logger.Error($"Could not build type {nodeType.Id}!");
                   }
-
                   break;
                }
-
-            case "Void":
-               {
-                  var spaces = new List<string>() { $"Ajuna.NetApi.Model.Types.Base" };
-                  typeDict.Add(nodeType.Id, ($"Ajuna.NetApi.Model.Types.Base.BaseVoid", spaces));
-                  break;
-               }
-
             case "Enum":
                {
-                  (string, List<string>) fullItem = EnumBuilder.Init(ProjectName, nodeType.Id, nodeType, typeDict).Create().Build(write: write, out bool success, basePath);
-                  if (success)
+                  EnumBuilder.Init(ProjectName, nodeType.Id, nodeType, typeDict).Create().Build(write: write, out bool success, basePath);
+                  if (!success)
                   {
-                     typeDict.Add(nodeType.Id, fullItem);
+                     Logger.Error($"Could not build type {nodeType.Id}!");
                   }
 
                   break;
                }
-
             default:
-               throw new NotImplementedException();
+               break;
          }
       }
-
-      private void CallPrimitive(NodeTypePrimitive nodeType, ref Dictionary<uint, (string, List<string>)> typeDict)
-      {
-         List<string> spaces = new() { $"Ajuna.NetApi.Model.Types.Primitive" };
-         string path = $"Ajuna.NetApi.Model.Types.Primitive.";
-         switch (nodeType.Primitive)
-         {
-            case TypeDefPrimitive.Bool:
-               typeDict.Add(nodeType.Id, (path + nameof(Bool), spaces));
-               break;
-            case TypeDefPrimitive.Char:
-               typeDict.Add(nodeType.Id, (path + nameof(PrimChar), spaces));
-               break;
-            case TypeDefPrimitive.Str:
-               typeDict.Add(nodeType.Id, (path + nameof(Str), spaces));
-               break;
-            case TypeDefPrimitive.U8:
-               typeDict.Add(nodeType.Id, (path + nameof(U8), spaces));
-               break;
-            case TypeDefPrimitive.U16:
-               typeDict.Add(nodeType.Id, (path + nameof(U16), spaces));
-               break;
-            case TypeDefPrimitive.U32:
-               typeDict.Add(nodeType.Id, (path + nameof(U32), spaces));
-               break;
-            case TypeDefPrimitive.U64:
-               typeDict.Add(nodeType.Id, (path + nameof(U64), spaces));
-               break;
-            case TypeDefPrimitive.U128:
-               typeDict.Add(nodeType.Id, (path + nameof(U128), spaces));
-               break;
-            case TypeDefPrimitive.U256:
-               typeDict.Add(nodeType.Id, (path + nameof(U256), spaces));
-               break;
-            case TypeDefPrimitive.I8:
-               typeDict.Add(nodeType.Id, (path + nameof(I8), spaces));
-               break;
-            case TypeDefPrimitive.I16:
-               typeDict.Add(nodeType.Id, (path + nameof(I16), spaces));
-               break;
-            case TypeDefPrimitive.I32:
-               typeDict.Add(nodeType.Id, (path + nameof(I32), spaces));
-               break;
-            case TypeDefPrimitive.I64:
-               typeDict.Add(nodeType.Id, (path + nameof(I64), spaces));
-               break;
-            case TypeDefPrimitive.I128:
-               typeDict.Add(nodeType.Id, (path + nameof(I128), spaces));
-               break;
-            case TypeDefPrimitive.I256:
-               typeDict.Add(nodeType.Id, (path + nameof(I256), spaces));
-               break;
-            default:
-               throw new NotImplementedException($"Please implement {nodeType.Primitive}, in Ajuna.NetApi.");
-         }
-      }
-
-      private static void CallTuple(NodeTypeTuple nodeType, ref Dictionary<uint, (string, List<string>)> typeDict)
-      {
-         var typeIds = new List<string>();
-         var imports = new List<string>();
-         for (int j = 0; j < nodeType.TypeIds.Length; j++)
-         {
-            uint typeId = nodeType.TypeIds[j];
-            if (!typeDict.TryGetValue(typeId, out (string, List<string>) fullItem))
-            {
-               typeIds = null;
-               break;
-            }
-
-            imports.AddRange(fullItem.Item2);
-            typeIds.Add(fullItem.Item1);
-         }
-
-         // all types found
-         if (typeIds != null)
-         {
-            string typeName = $"BaseTuple{(typeIds.Count > 0 ? "<" + string.Join(',', typeIds.ToArray()) + ">" : "")}";
-            typeDict.Add(nodeType.Id, (typeName, imports.Distinct().ToList()));
-         }
-      }
-
+      
       private static Dictionary<string, int> GetRuntimeIndex(Dictionary<uint, NodeType> nodeTypes, string runtime, string runtimeType)
       {
          NodeType nodeType = nodeTypes.Select(p => p.Value).Where(p => p.Path != null && p.Path.Length == 2 && p.Path[0] == runtime && p.Path[1] == runtimeType).FirstOrDefault();

--- a/Tools/Ajuna.DotNet/Service/Generators/Base/SolutionGeneratorBase.cs
+++ b/Tools/Ajuna.DotNet/Service/Generators/Base/SolutionGeneratorBase.cs
@@ -46,7 +46,7 @@ namespace Ajuna.DotNet.Service.Generators.Base
 
       protected NodeTypeResolver GenerateTypes(Dictionary<uint, NodeType> nodeTypes, string basePath, bool write)
       {
-         var resolver = new NodeTypeResolver(NodeRuntime, nodeTypes);
+         var resolver = new NodeTypeResolver(NodeRuntime, ProjectName, nodeTypes);
 
          foreach (KeyValuePair<uint, NodeTypeResolved> kvp in resolver.TypeNames)
          {

--- a/Tools/Ajuna.DotNet/Service/Generators/Base/SolutionGeneratorBase.cs
+++ b/Tools/Ajuna.DotNet/Service/Generators/Base/SolutionGeneratorBase.cs
@@ -72,7 +72,7 @@ namespace Ajuna.DotNet.Service.Generators.Base
                case TypeDefEnum.Variant:
                   {
                      var type = nodeType as NodeTypeVariant;
-                     string variantType = GetVariantType(NodeRuntime, string.Join('.', nodeType.Path));
+                     string variantType = NodeTypeResolver.GetVariantType(string.Join('.', nodeType.Path));
                      CallVariant(variantType, type, ref resolver, write, basePath);
                      break;
                   }
@@ -96,43 +96,6 @@ namespace Ajuna.DotNet.Service.Generators.Base
          }
 
          return resolver;
-      }
-
-      private static string GetVariantType(string nodeRunetime, string path)
-      {
-         if (path == "Option")
-         {
-            return path;
-         }
-         else if (path == "Result")
-         {
-            return path;
-         }
-         else if ((path.Contains("pallet_") || path.Contains(".pallet.")) && path.Contains(".Call"))
-         {
-            return "Call";
-         }
-         else if ((path.Contains("pallet_") || path.Contains(".pallet.")) &&
-                  (path.Contains(".Event") || path.Contains(".RawEvent")))
-         {
-            return "Event";
-         }
-         else if ((path.Contains("pallet_") || path.Contains(".pallet.")) && path.Contains(".Error"))
-         {
-            return "Error";
-         }
-         else if (path.Contains($"{nodeRunetime}.Event") || path.Contains($"{nodeRunetime}.Call"))
-         {
-            return "Runtime";
-         }
-         else if (path.Contains(".Void"))
-         {
-            return "Void";
-         }
-         else
-         {
-            return "Enum";
-         }
       }
 
       private void CallVariant(string variantType, NodeTypeVariant nodeType, ref NodeTypeResolver typeDict, bool write, string basePath = null)

--- a/Tools/Ajuna.DotNet/Service/Generators/NetApiGenerator.cs
+++ b/Tools/Ajuna.DotNet/Service/Generators/NetApiGenerator.cs
@@ -22,34 +22,34 @@ namespace Ajuna.DotNet.Service.Generators
       {
          // dirty workaround for generics.
          // TODO (svnscha) Why dirty workaround?
-         SolutionGeneratorBase.GetGenericStructs(metadata.NodeMetadata.Types);
+         GetGenericStructs(metadata.NodeMetadata.Types);
 
          // generate types
-         Dictionary<uint, (string, List<string>)> typeDict = GenerateTypes(metadata.NodeMetadata.Types, _projectSettings.ProjectDirectory, write: true);
+         NodeTypeResolver typeDict = GenerateTypes(metadata.NodeMetadata.Types, _projectSettings.ProjectDirectory, write: true);
 
          // generate modules
          GenerateModules(ProjectName, metadata.NodeMetadata.Modules, typeDict, metadata.NodeMetadata.Types, _projectSettings.ProjectDirectory);
 
          // generate base event handler
          // TODO (svnscha) Why disabled?
-         //GenerateBaseEvents(metadata.NodeMetadata.Modules, typeDict, metadata.NodeMetadata.Types);
+         // GenerateBaseEvents(metadata.NodeMetadata.Modules, typeDict, metadata.NodeMetadata.Types);
       }
 
-      private static void GenerateModules(string projectName, Dictionary<uint, PalletModule> modules, Dictionary<uint, (string, List<string>)> typeDict, Dictionary<uint, NodeType> nodeTypes, string basePath)
+      private static void GenerateModules(string projectName, Dictionary<uint, PalletModule> modules, NodeTypeResolver typeDict, Dictionary<uint, NodeType> nodeTypes, string basePath)
       {
-         List<(string, List<string>)> moduleNames = new();
+         List<string> modulesResolved = new();
          foreach (PalletModule module in modules.Values)
          {
-            (string, List<string>) moduleNameTuple = ModuleGenBuilder
+            ModuleGenBuilder
                 .Init(projectName, module.Index, module, typeDict, nodeTypes)
                 .Create()
                 .Build(write: true, out bool _, basePath);
 
-            moduleNames.Add(moduleNameTuple);
+            modulesResolved.Add($"{module.Name}Storage");
          }
 
          ClientBuilder
-             .Init(projectName, 0, moduleNames, typeDict).Create()
+             .Init(projectName, 0, modulesResolved, typeDict).Create()
              .Build(write: true, out bool _, basePath);
       }
    }

--- a/Tools/Ajuna.DotNet/Service/Generators/RestServiceGenerator.cs
+++ b/Tools/Ajuna.DotNet/Service/Generators/RestServiceGenerator.cs
@@ -26,7 +26,7 @@ namespace Ajuna.DotNet.Service.Generators
 
          // Generate types as if we were generating them for Types project but just keep them in memory
          // so we can reference these types and we don't output all the types while generating the rest service.
-         Dictionary<uint, (string, List<string>)> typeDict = GenerateTypes(metadata.NodeMetadata.Types, string.Empty, write: false);
+         NodeTypeResolver typeDict = GenerateTypes(metadata.NodeMetadata.Types, string.Empty, write: false);
 
          foreach (PalletModule module in metadata.NodeMetadata.Modules.Values)
          {

--- a/Tools/Ajuna.DotNet/Service/Node/Base/ClientBuilderBase.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/Base/ClientBuilderBase.cs
@@ -1,16 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using System.CodeDom;
+using System.Collections.Generic;
 
 namespace Ajuna.DotNet.Service.Node.Base
 {
    public abstract class ClientBuilderBase : BuilderBase
    {
-      public List<(string, List<string>)> ModuleNames { get; }
+      public List<string> ModuleNames { get; }
 
-      public ClientBuilderBase(string projectName, uint id, List<(string, List<string>)> moduleNames, Dictionary<uint, (string, List<string>)> typeDict)
+      public ClientBuilderBase(string projectName, uint id, List<string> moduleNames, NodeTypeResolver typeDict)
           : base(projectName, id, typeDict)
       {
          ModuleNames = moduleNames;
          NamespaceName = $"{ProjectName}.Generated";
+         ImportsNamespace.Imports.Add(new CodeNamespaceImport($"{ProjectName}.Generated.Storage"));
       }
    }
 }

--- a/Tools/Ajuna.DotNet/Service/Node/Base/ModuleBuilderBase.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/Base/ModuleBuilderBase.cs
@@ -12,7 +12,7 @@ namespace Ajuna.DotNet.Service.Node.Base
 
       public string PrefixName { get; private set; }
 
-      public ModuleBuilderBase(string projectName, uint id, PalletModule module, Dictionary<uint, (string, List<string>)> typeDict,
+      public ModuleBuilderBase(string projectName, uint id, PalletModule module, NodeTypeResolver typeDict,
           Dictionary<uint, NodeType> nodeTypes)
           : base(projectName, id, typeDict)
       {

--- a/Tools/Ajuna.DotNet/Service/Node/Base/ModulesBuilderBase.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/Base/ModulesBuilderBase.cs
@@ -9,7 +9,7 @@ namespace Ajuna.DotNet.Service.Node.Base
 
       public PalletModule[] Modules { get; private set; }
 
-      public ModulesBuilderBase(string projectName, uint id, PalletModule[] modules, Dictionary<uint, (string, List<string>)> typeDict,
+      public ModulesBuilderBase(string projectName, uint id, PalletModule[] modules, NodeTypeResolver typeDict,
           Dictionary<uint, NodeType> nodeTypes)
           : base(projectName, id, typeDict)
       {

--- a/Tools/Ajuna.DotNet/Service/Node/Base/TypeBuilderBase.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/Base/TypeBuilderBase.cs
@@ -10,28 +10,11 @@ namespace Ajuna.DotNet.Service.Node.Base
    {
       public NodeType TypeDef { get; }
 
-      public TypeBuilderBase(string projectName, uint id, NodeType typeDef, Dictionary<uint, (string, List<string>)> typeDict)
-          : base(projectName, id, typeDict)
+      public TypeBuilderBase(string projectName, uint id, NodeType typeDef, NodeTypeResolver resolver)
+          : base(projectName, id, resolver)
       {
          TypeDef = typeDef;
-         NamespaceName = $"{ProjectName}.Generated.Model.{TypeNameSpace(typeDef.Path)}";
-      }
-
-      private string TypeNameSpace(string[] path)
-      {
-         if (path == null || path.Length < 2)
-         {
-            return "Base";
-         }
-
-         // heck if we have a versioned name space
-         IEnumerable<string> vWhere = path.Where(p => Regex.IsMatch(p, @"v[0-9]+"));
-         if (vWhere.Any())
-         {
-            return path[0].MakeMethod() + "." + vWhere.First().MakeMethod();
-         }
-
-         return path[0].MakeMethod();
+         NamespaceName = resolver.GetNamespace(id);
       }
    }
 }

--- a/Tools/Ajuna.DotNet/Service/Node/ClientBuilder.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/ClientBuilder.cs
@@ -11,12 +11,12 @@ namespace Ajuna.DotNet.Service.Node
 {
    public class ClientBuilder : ClientBuilderBase
    {
-      private ClientBuilder(string projectName, uint id, List<(string, List<string>)> moduleNames, Dictionary<uint, (string, List<string>)> typeDict) :
+      private ClientBuilder(string projectName, uint id, List<string> moduleNames, NodeTypeResolver typeDict) :
           base(projectName, id, moduleNames, typeDict)
       {
       }
 
-      public static ClientBuilder Init(string projectName, uint id, List<(string, List<string>)> moduleNames, Dictionary<uint, (string, List<string>)> typeDict)
+      public static ClientBuilder Init(string projectName, uint id, List<string> moduleNames, NodeTypeResolver typeDict)
       {
          return new ClientBuilder(projectName, id, moduleNames, typeDict);
       }
@@ -78,28 +78,25 @@ namespace Ajuna.DotNet.Service.Node
          //        new CodeVariableReferenceExpression(eventKeyField.Name),
          //        new CodeObjectCreateExpression(eventKeyField.Type, new CodeExpression[] { })));
 
-         foreach ((string, List<string>) tuple in ModuleNames)
+         foreach (string moduleName in ModuleNames)
          {
             string[] pallets = new string[] { "Storage" }; // , "Call"};
 
             foreach (string pallet in pallets)
             {
-               string name = tuple.Item1.Split('.').Last() + pallet;
-               string referenceName = tuple.Item2[0] + "." + name;
-
                CodeMemberField clientField = new()
                {
                   Attributes = MemberAttributes.Public,
-                  Name = name,
-                  Type = new CodeTypeReference(referenceName)
+                  Name = moduleName,
+                  Type = new CodeTypeReference(moduleName)
                };
-               clientField.Comments.AddRange(GetComments(new string[] { $"{name} storage calls." }, null, null));
+               clientField.Comments.AddRange(GetComments(new string[] { $"{moduleName} storage calls." }, null, null));
                targetClass.Members.Add(clientField);
 
                CodeFieldReferenceExpression fieldReference =
-                   new(new CodeThisReferenceExpression(), name);
+                   new(new CodeThisReferenceExpression(), moduleName);
 
-               var createPallet = new CodeObjectCreateExpression(referenceName);
+               var createPallet = new CodeObjectCreateExpression(moduleName);
                createPallet.Parameters.Add(new CodeThisReferenceExpression());
                constructor.Statements.Add(new CodeAssignStatement(fieldReference, createPallet));
             }

--- a/Tools/Ajuna.DotNet/Service/Node/EnumBuilder.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/EnumBuilder.cs
@@ -4,6 +4,7 @@ using Ajuna.NetApi.Model.Types;
 using System;
 using System.CodeDom;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 
@@ -11,12 +12,12 @@ namespace Ajuna.DotNet.Service.Node
 {
    public class EnumBuilder : TypeBuilderBase
    {
-      private EnumBuilder(string projectName, uint id, NodeTypeVariant typeDef, Dictionary<uint, (string, List<string>)> typeDict)
+      private EnumBuilder(string projectName, uint id, NodeTypeVariant typeDef, NodeTypeResolver typeDict)
           : base(projectName, id, typeDef, typeDict)
       {
       }
 
-      public static EnumBuilder Init(string projectName, uint id, NodeTypeVariant typeDef, Dictionary<uint, (string, List<string>)> typeDict)
+      public static EnumBuilder Init(string projectName, uint id, NodeTypeVariant typeDef, NodeTypeResolver typeDict)
       {
          return new EnumBuilder(projectName, id, typeDef, typeDict);
       }
@@ -28,6 +29,7 @@ namespace Ajuna.DotNet.Service.Node
          string enumName = $"{typeDef.Path.Last()}";
 
          ClassName = $"Enum{enumName}";
+         
          ReferenzName = $"{NamespaceName}.{ClassName}";
          CodeNamespace typeNamespace = new(NamespaceName);
          TargetUnit.Namespaces.Add(typeNamespace);
@@ -78,8 +80,8 @@ namespace Ajuna.DotNet.Service.Node
                      {
                         if (variant.TypeFields.Length == 1)
                         {
-                           (string, List<string>) fullItem = GetFullItemPath(variant.TypeFields[0].TypeId);
-                           codeTypeRef.TypeArguments.Add(new CodeTypeReference(fullItem.Item1));
+                           NodeTypeResolved item = GetFullItemPath(variant.TypeFields[0].TypeId);
+                           codeTypeRef.TypeArguments.Add(new CodeTypeReference(item.ToString()));
                         }
                         else
                         {
@@ -87,8 +89,8 @@ namespace Ajuna.DotNet.Service.Node
 
                            foreach (NodeTypeField field in variant.TypeFields)
                            {
-                              (string, List<string>) fullItem = GetFullItemPath(field.TypeId);
-                              baseTuple.TypeArguments.Add(new CodeTypeReference(fullItem.Item1));
+                              NodeTypeResolved item = GetFullItemPath(field.TypeId);
+                              baseTuple.TypeArguments.Add(new CodeTypeReference(item.ToString()));
                            }
                            codeTypeRef.TypeArguments.Add(baseTuple);
                         }
@@ -128,7 +130,6 @@ namespace Ajuna.DotNet.Service.Node
       private CodeTypeMemberCollection GetEnumEra()
       {
 
-         ImportsNamespace.Imports.Add(new CodeNamespaceImport($"{ProjectName}.Generated.Model.Base"));
          ImportsNamespace.Imports.Add(new CodeNamespaceImport("Ajuna.NetApi.Model.Types"));
          ImportsNamespace.Imports.Add(new CodeNamespaceImport("Ajuna.NetApi.Model.Types.Primitive"));
 

--- a/Tools/Ajuna.DotNet/Service/Node/EnumBuilder.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/EnumBuilder.cs
@@ -29,7 +29,6 @@ namespace Ajuna.DotNet.Service.Node
          string enumName = $"{typeDef.Path.Last()}";
 
          ClassName = $"Enum{enumName}";
-         
          ReferenzName = $"{NamespaceName}.{ClassName}";
          CodeNamespace typeNamespace = new(NamespaceName);
          TargetUnit.Namespaces.Add(typeNamespace);
@@ -48,81 +47,78 @@ namespace Ajuna.DotNet.Service.Node
          }
          typeNamespace.Types.Add(TargetType);
 
-         if (typeDef.Variants != null)
+         var targetClass = new CodeTypeDeclaration(ClassName)
          {
-            var targetClass = new CodeTypeDeclaration(ClassName)
-            {
-               IsClass = true,
-               TypeAttributes = TypeAttributes.Public | TypeAttributes.Sealed
-            };
-            targetClass.Comments.AddRange(GetComments(typeDef.Docs, typeDef));
+            IsClass = true,
+            TypeAttributes = TypeAttributes.Public | TypeAttributes.Sealed
+         };
+         targetClass.Comments.AddRange(GetComments(typeDef.Docs, typeDef));
 
-            if (typeDef.Variants.All(p => p.TypeFields == null))
+         if (typeDef.Variants == null || typeDef.Variants.All(p => p.TypeFields == null))
+         {
+            targetClass.BaseTypes.Add(new CodeTypeReference($"BaseEnum<{enumName}>"));
+            typeNamespace.Types.Add(targetClass);
+         }
+         else
+         {
+            var codeTypeRef = new CodeTypeReference("BaseEnumExt");
+            codeTypeRef.TypeArguments.Add(new CodeTypeReference(enumName));
+            if (typeDef.Variants.Length < 29)
             {
-               targetClass.BaseTypes.Add(new CodeTypeReference($"BaseEnum<{enumName}>"));
-               typeNamespace.Types.Add(targetClass);
-            }
-            else
-            {
-               var codeTypeRef = new CodeTypeReference("BaseEnumExt");
-               codeTypeRef.TypeArguments.Add(new CodeTypeReference(enumName));
-               if (typeDef.Variants.Length < 29)
+               for (int i = 0; i < typeDef.Variants.Length; i++)
                {
-                  for (int i = 0; i < typeDef.Variants.Length; i++)
+                  TypeVariant variant = typeDef.Variants[i];
+                  if (variant.TypeFields == null)
                   {
-                     TypeVariant variant = typeDef.Variants[i];
-                     if (variant.TypeFields == null)
+                     // add void type
+                     codeTypeRef.TypeArguments.Add(new CodeTypeReference("BaseVoid"));
+                  }
+                  else
+                  {
+                     if (variant.TypeFields.Length == 1)
                      {
-                        // add void type
-                        codeTypeRef.TypeArguments.Add(new CodeTypeReference("BaseVoid"));
+                        NodeTypeResolved item = GetFullItemPath(variant.TypeFields[0].TypeId);
+                        codeTypeRef.TypeArguments.Add(new CodeTypeReference(item.ToString()));
                      }
                      else
                      {
-                        if (variant.TypeFields.Length == 1)
-                        {
-                           NodeTypeResolved item = GetFullItemPath(variant.TypeFields[0].TypeId);
-                           codeTypeRef.TypeArguments.Add(new CodeTypeReference(item.ToString()));
-                        }
-                        else
-                        {
-                           var baseTuple = new CodeTypeReference("BaseTuple");
+                        var baseTuple = new CodeTypeReference("BaseTuple");
 
-                           foreach (NodeTypeField field in variant.TypeFields)
-                           {
-                              NodeTypeResolved item = GetFullItemPath(field.TypeId);
-                              baseTuple.TypeArguments.Add(new CodeTypeReference(item.ToString()));
-                           }
-                           codeTypeRef.TypeArguments.Add(baseTuple);
+                        foreach (NodeTypeField field in variant.TypeFields)
+                        {
+                           NodeTypeResolved item = GetFullItemPath(field.TypeId);
+                           baseTuple.TypeArguments.Add(new CodeTypeReference(item.ToString()));
                         }
+                        codeTypeRef.TypeArguments.Add(baseTuple);
                      }
                   }
                }
-               // Unhandled enumerations are manually done
-               else
-               {
-                  codeTypeRef.TypeArguments.Add(new CodeTypeReference("BaseVoid"));
-
-                  switch (enumName)
-                  {
-                     case "Era":
-                        targetClass.Members.AddRange(GetEnumEra());
-                        break;
-                     case "Data":
-                        targetClass.Members.AddRange(GetEnumData());
-                        break;
-                     // TODO (svnscha): Why is this not supported yet?
-                     case "Event":
-                     case "DispatchError":
-                     case "Call":
-                        break;
-                     default:
-                        throw new NotImplementedException("Enum extension can't handle such big sized typed rust enumeration, please create a manual fix for it.");
-                  }
-               }
-
-               targetClass.BaseTypes.Add(codeTypeRef);
-               typeNamespace.Types.Add(targetClass);
             }
+            // Unhandled enumerations are manually done
+            else
+            {
+               codeTypeRef.TypeArguments.Add(new CodeTypeReference("BaseVoid"));
+
+               switch (enumName)
+               {
+                  case "Era":
+                     targetClass.Members.AddRange(GetEnumEra());
+                     break;
+                  case "Data":
+                     targetClass.Members.AddRange(GetEnumData());
+                     break;
+                  // TODO (svnscha): Why is this not supported yet?
+                  case "Event":
+                  case "DispatchError":
+                  case "Call":
+                     break;
+                  default:
+                     throw new NotImplementedException("Enum extension can't handle such big sized typed rust enumeration, please create a manual fix for it.");
+               }
+            }
+
+            targetClass.BaseTypes.Add(codeTypeRef);
+            typeNamespace.Types.Add(targetClass);
          }
          return this;
       }

--- a/Tools/Ajuna.DotNet/Service/Node/EnumBuilder.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/EnumBuilder.cs
@@ -187,9 +187,9 @@ namespace Ajuna.DotNet.Service.Node
       private CodeTypeMemberCollection GetEnumData()
       {
          ImportsNamespace.Imports.Add(new CodeNamespaceImport($"System"));
-         ImportsNamespace.Imports.Add(new CodeNamespaceImport($"{ProjectName}.Generated.Model.Base"));
          ImportsNamespace.Imports.Add(new CodeNamespaceImport("Ajuna.NetApi.Model.Types"));
          ImportsNamespace.Imports.Add(new CodeNamespaceImport("Ajuna.NetApi.Model.Types.Primitive"));
+         ImportsNamespace.Imports.Add(new CodeNamespaceImport($"{ProjectName}.Generated.Types.Base"));
 
          var result = new CodeTypeMemberCollection();
 

--- a/Tools/Ajuna.DotNet/Service/Node/EventModuleBuilder.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/EventModuleBuilder.cs
@@ -10,12 +10,12 @@ namespace Ajuna.DotNet.Service.Node
 {
    public class EventModuleBuilder : ModulesBuilderBase
    {
-      private EventModuleBuilder(string projectName, uint id, PalletModule[] modules, Dictionary<uint, (string, List<string>)> typeDict, Dictionary<uint, NodeType> nodeTypes) :
+      private EventModuleBuilder(string projectName, uint id, PalletModule[] modules, NodeTypeResolver typeDict, Dictionary<uint, NodeType> nodeTypes) :
           base(projectName, id, modules, typeDict, nodeTypes)
       {
       }
 
-      public static EventModuleBuilder Init(string projectName, uint id, PalletModule[] modules, Dictionary<uint, (string, List<string>)> typeDict, Dictionary<uint, NodeType> nodeTypes)
+      public static EventModuleBuilder Init(string projectName, uint id, PalletModule[] modules, NodeTypeResolver typeDict, Dictionary<uint, NodeType> nodeTypes)
       {
          return new EventModuleBuilder(projectName, id, modules, typeDict, nodeTypes);
       }
@@ -68,8 +68,8 @@ namespace Ajuna.DotNet.Service.Node
                      {
                         foreach (NodeTypeField field in variant.TypeFields)
                         {
-                           (string, List<string>) fullItem = GetFullItemPath(field.TypeId);
-                           codeTypeRef.TypeArguments.Add(new CodeTypeReference(fullItem.Item1));
+                           NodeTypeResolved fullItem = GetFullItemPath(field.TypeId);
+                           codeTypeRef.TypeArguments.Add(new CodeTypeReference(fullItem.ToString()));
                         }
                      }
                      eventClass.BaseTypes.Add(codeTypeRef);

--- a/Tools/Ajuna.DotNet/Service/Node/NodeTypeResolver.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/NodeTypeResolver.cs
@@ -1,0 +1,332 @@
+﻿#nullable enable
+using Ajuna.DotNet.Extensions;
+using Ajuna.NetApi.Model.Meta;
+using Ajuna.NetApi.Model.Types.Metadata.V14;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Ajuna.DotNet.Service.Node
+{
+   public class NodeTypeResolved
+   {
+      public NodeTypeResolved(NodeType nodeType, NodeTypeName name)
+      {
+         NodeType = nodeType;
+         Name = name;
+      }
+
+      public NodeType NodeType { get; private set; }
+      public NodeTypeName Name { get; private set; }
+
+      public override string ToString() => Name.ToString();
+
+      public string ClassName => Name.ClassName;
+      public string Namespace => Name.Namespace;
+   }
+
+   public enum NodeTypeNamespaceSource
+   {
+      Generated,
+      Base,
+      Primitive
+   }
+
+   public class NodeTypeName
+   {
+      public NodeTypeResolver Resolver { get; private set; }
+      public NodeTypeNamespaceSource NamespaceSource { get; private set; }
+      public string BaseName { get; private set; }
+      public string ClassName => BaseName.Split('.').Last();
+      public string BaseNamePrefix { get; private set; }
+      public NodeTypeName[]? Arguments { get; private set; }
+
+      public string Namespace
+      {
+         get
+         {
+            string[]? paths = BaseName.Split('.').ToArray();
+            string[]? reduced = paths.Take(paths.Length - 1).ToArray();
+            string? result = string.Join('.', reduced);
+            
+            if (string.IsNullOrEmpty(result))
+            {
+               switch (NamespaceSource)
+               {
+                  case NodeTypeNamespaceSource.Primitive:
+                     return "Ajuna.NetApi.Model.Types.Primitive";
+                  case NodeTypeNamespaceSource.Generated:
+                     return "AjunaExample.NetApi.Generated.Types.Base";
+                  default:
+                     break;
+               }
+
+               return "Ajuna.NetApi.Model.Types.Base";
+            }
+
+            // TODO (svnscha) use configurable project name
+            return $"AjunaExample.NetApi.Generated.Model.{result}";
+         }
+      }
+
+      public static NodeTypeName Primitive(NodeTypeResolver resolver, string baseName) => new NodeTypeName(resolver, NodeTypeNamespaceSource.Primitive, baseName, null);
+      public static NodeTypeName Base(NodeTypeResolver resolver, string baseName) => new NodeTypeName(resolver, NodeTypeNamespaceSource.Base, baseName, null);
+      public static NodeTypeName Base(NodeTypeResolver resolver, string baseName, NodeTypeName[]? arguments) => new NodeTypeName(resolver, NodeTypeNamespaceSource.Base, baseName, arguments);
+      public static NodeTypeName Generated(NodeTypeResolver resolver, string baseName) => new NodeTypeName(resolver, NodeTypeNamespaceSource.Generated, baseName, null);
+      public static NodeTypeName Generated(NodeTypeResolver resolver, string baseName, NodeTypeName[]? arguments) => new NodeTypeName(resolver, NodeTypeNamespaceSource.Generated, baseName, arguments);
+
+      internal static NodeTypeName Array(NodeTypeResolver nodeTypeResolver, NodeTypeName nodeTypeName, uint length)
+      {
+         var result = new NodeTypeName(nodeTypeResolver, NodeTypeNamespaceSource.Generated, nodeTypeName.BaseName, nodeTypeName.Arguments)
+         {
+            BaseNamePrefix = $"Arr{length}"
+         };
+         return result;
+      }
+
+      private NodeTypeName(NodeTypeResolver resolver, NodeTypeNamespaceSource namespaceType, string baseName, NodeTypeName[]? arguments)
+      {
+         Resolver = resolver;
+         NamespaceSource = namespaceType;
+         BaseName = baseName;
+         Arguments = arguments;
+         BaseNamePrefix = string.Empty;
+      }
+
+      public override string ToString()
+      {
+         string baseQualified;
+
+         if (string.IsNullOrEmpty(BaseNamePrefix))
+         {
+            baseQualified = $"{Namespace}.{ClassName}";
+         }
+         else
+         {
+            baseQualified = $"{Namespace}.{BaseNamePrefix}{ClassName}";
+         }
+
+         if (Arguments == null)
+         {
+            return baseQualified;
+         }
+
+         return $"{baseQualified}<{string.Join(", ", Arguments.Select(x => x.ToString()).ToArray())}>";
+      }
+   }
+
+   public class NodeTypeResolver
+   {
+      protected string NodeRuntime { get; private set; }
+
+      public Dictionary<uint, NodeTypeResolved> TypeNames { get; private set; }
+
+      public NodeTypeResolver(string nodeRuntime, Dictionary<uint, NodeType> types)
+      {
+         NodeRuntime = nodeRuntime;
+         TypeNames = Resolve(types);
+      }
+
+      private Dictionary<uint, NodeTypeResolved> Resolve(Dictionary<uint, NodeType> types)
+      {
+         var result = new Dictionary<uint, NodeTypeResolved>();
+
+         foreach (uint typeId in types.Keys)
+         {
+            NodeTypeName name = ResolveTypeName(typeId, types);
+            result.Add(typeId, new NodeTypeResolved(types[typeId], name));
+         }
+
+         return result;
+      }
+
+      private NodeTypeName ResolveTypeName(uint typeId, Dictionary<uint, NodeType> types)
+      {
+         NodeType nodeType = types[typeId];
+         switch (nodeType.TypeDef)
+         {
+            case TypeDefEnum.Composite:
+               {
+                  var nodeTypeComposite = (NodeTypeComposite)nodeType;
+                  EnsurePathIsNotNull(nodeTypeComposite.Path);
+                  return NodeTypeName.Generated(this, ResolvePath(nodeTypeComposite.Path, string.Empty));
+               }
+            case TypeDefEnum.Variant:
+               {
+                  var nodeTypeVariant = (NodeTypeVariant)nodeType;
+                  EnsurePathIsNotNull(nodeTypeVariant.Path);
+                  return ResolveVariantType(nodeTypeVariant, types);
+               }
+            case TypeDefEnum.Sequence:
+               {
+                  var nodeTypeSequence = (NodeTypeSequence)nodeType;
+                  EnsurePathIsNull(nodeTypeSequence.Path);
+                  return NodeTypeName.Base(this, "BaseVec", new NodeTypeName[] { ResolveTypeName(nodeTypeSequence.TypeId, types) });
+               }
+            case TypeDefEnum.Array:
+               {
+                  var nodeTypeArray = (NodeTypeArray)nodeType;
+                  EnsurePathIsNull(nodeTypeArray.Path);
+                  return NodeTypeName.Array(this, ResolveTypeName(nodeTypeArray.TypeId, types), nodeTypeArray.Length);
+               }
+            case TypeDefEnum.Tuple:
+               {
+                  var nodeTypeTuple = (NodeTypeTuple)nodeType;
+                  EnsurePathIsNull(nodeTypeTuple.Path);
+                  if (nodeTypeTuple.TypeIds == null || nodeTypeTuple.TypeIds.Length == 0)
+                  {
+                     return NodeTypeName.Base(this, "BaseTuple");
+                  }
+
+                  EnsureTypeIdsIsNotNull(nodeTypeTuple.TypeIds);
+#pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
+                  NodeTypeName[]? arguments = nodeTypeTuple.TypeIds.Select(x => ResolveTypeName(x, types)).ToArray();
+#pragma warning restore CS8619 // Nullability of reference types in value doesn't match target type.
+                  return NodeTypeName.Base(this, "BaseTuple", arguments);
+               }
+            case TypeDefEnum.Primitive:
+               {
+                  var nodeTypePrimitive = (NodeTypePrimitive)nodeType;
+                  EnsurePathIsNull(nodeTypePrimitive.Path);
+                  return NodeTypeName.Primitive(this, nodeTypePrimitive.Primitive.ToString());
+               }
+            case TypeDefEnum.Compact:
+               {
+                  var nodeTypeCompact = (NodeTypeCompact)nodeType;
+                  EnsurePathIsNull(nodeTypeCompact.Path);
+                  return NodeTypeName.Base(this, "BaseCom", new NodeTypeName[] { ResolveTypeName(nodeTypeCompact.TypeId, types) });
+               }
+            case TypeDefEnum.BitSequence:
+               {
+                  var nodeTypeBitSequence = (NodeTypeBitSequence)nodeType;
+                  EnsurePathIsNull(nodeTypeBitSequence.Path);
+                  NodeTypeName type1 = ResolveTypeName(nodeTypeBitSequence.TypeIdStore, types);
+                  NodeTypeName type2 = ResolveTypeName(nodeTypeBitSequence.TypeIdOrder, types);
+                  return NodeTypeName.Base(this, "BaseBitSeq", new NodeTypeName[] { type1, type2 });
+               }
+            default:
+               break;
+         }
+
+         throw new NotImplementedException("This is not implemented yet.");
+      }
+
+      private NodeTypeName ResolveVariantType(NodeTypeVariant nodeTypeVariant, Dictionary<uint, NodeType> types)
+      {
+         string variantType = GetVariantType(string.Join('.', nodeTypeVariant.Path));
+         switch (variantType)
+         {
+            case "Option":
+               return NodeTypeName.Base(this, "BaseOpt", new NodeTypeName[] { ResolveTypeName(nodeTypeVariant.Variants[1].TypeFields[0].TypeId, types) });
+            case "Result":
+               return NodeTypeName.Base(this, "BaseTuple<BaseTuple, EnumDispatchError>");
+            case "Void":
+               return NodeTypeName.Base(this, "BaseVoid");
+            default:
+               break;
+         }
+
+         return NodeTypeName.Generated(this, ResolvePath(nodeTypeVariant.Path, variantType));
+      }
+
+      private string GetVariantType(string path)
+      {
+         if (path == "Option")
+         {
+            return path;
+         }
+         else if (path == "Result")
+         {
+            return path;
+         }
+         else if ((path.Contains("pallet_") || path.Contains(".pallet.")) && path.Contains(".Call"))
+         {
+            return "Call";
+         }
+         else if ((path.Contains("pallet_") || path.Contains(".pallet.")) &&
+                  (path.Contains(".Event") || path.Contains(".RawEvent")))
+         {
+            return "Event";
+         }
+         else if ((path.Contains("pallet_") || path.Contains(".pallet.")) && path.Contains(".Error"))
+         {
+            return "Error";
+         }
+         //else if (path.Contains($"{NodeRuntime}.Event") || path.Contains($"{NodeRuntime}.Call"))
+         //{
+         //   return "Runtime";
+         //}
+         else if (path.Contains(".Void"))
+         {
+            return "Void";
+         }
+
+         return "Enum";
+      }
+
+      // private string ResolvePath(string[] path, string prefix) => ResolvePathInternal(path.Select(x => x.MakeMethod().ToUpperFirst()).ToArray(), prefix);
+      private string ResolvePath(string[] path, string prefix) => ResolvePathInternal(path, prefix);
+
+      private string ResolvePathInternal(string[] path, string prefix)
+      {
+         if (path.Length == 1)
+         {
+            return $"{prefix}{string.Join(".", path)}";
+         }
+
+         string? lastElement = path[path.Length - 1];
+         string[]? previousElements = path.Take(path.Length - 1).ToArray();
+         return $"{ResolvePathInternal(previousElements, string.Empty)}.{prefix}{lastElement}";
+      }
+
+
+      private static void EnsureTypeIdsIsNotNull(uint[] typeIds)
+      {
+         if (typeIds == null || typeIds.Length == 0)
+         {
+            throw new Exception("Expected that TypeIds are not null and not empty!");
+         }
+      }
+
+      private static void EnsurePathIsNotNull(string[] path)
+      {
+         if (path == null || path.Length == 0)
+         {
+            throw new Exception("Expected that path is not null and not empty!");
+         }
+      }
+
+      private static void EnsurePathIsNull(string[] path)
+      {
+         if (path != null)
+         {
+            throw new Exception("Expected that path is null!");
+         }
+      }
+
+      internal string GetNamespace(uint id)
+      {
+         NodeTypeResolved nodeTypeResolved = TypeNames[id];
+         return nodeTypeResolved.Namespace;
+      }
+
+      private string TypeNameSpace(string[] path)
+      {
+         if (path == null || path.Length < 2)
+         {
+            return "Base";
+         }
+
+         // heck if we have a versioned name space
+         IEnumerable<string> vWhere = path.Where(p => Regex.IsMatch(p, @"v[0-9]+"));
+         if (vWhere.Any())
+         {
+            return path[0].MakeMethod() + "." + vWhere.First().MakeMethod();
+         }
+
+         return path[0].MakeMethod();
+      }
+   }
+}

--- a/Tools/Ajuna.DotNet/Service/Node/NodeTypeResolver.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/NodeTypeResolver.cs
@@ -58,7 +58,7 @@ namespace Ajuna.DotNet.Service.Node
                   case NodeTypeNamespaceSource.Primitive:
                      return "Ajuna.NetApi.Model.Types.Primitive";
                   case NodeTypeNamespaceSource.Generated:
-                     return "AjunaExample.NetApi.Generated.Types.Base";
+                     return $"{Resolver.NetApiProjectName}.Generated.Types.Base";
                   default:
                      break;
                }
@@ -67,7 +67,7 @@ namespace Ajuna.DotNet.Service.Node
             }
 
             // TODO (svnscha) use configurable project name
-            return $"AjunaExample.NetApi.Generated.Model.{result}";
+            return $"{Resolver.NetApiProjectName}.Generated.Model.{result}";
          }
       }
 
@@ -125,10 +125,12 @@ namespace Ajuna.DotNet.Service.Node
       protected string NodeRuntime { get; private set; }
 
       public Dictionary<uint, NodeTypeResolved> TypeNames { get; private set; }
+      public string NetApiProjectName { get; private set; }
 
-      public NodeTypeResolver(string nodeRuntime, Dictionary<uint, NodeType> types)
+      public NodeTypeResolver(string nodeRuntime, string netApiProjectName, Dictionary<uint, NodeType> types)
       {
          NodeRuntime = nodeRuntime;
+         NetApiProjectName = netApiProjectName;
          TypeNames = Resolve(types);
       }
 

--- a/Tools/Ajuna.DotNet/Service/Node/NodeTypeResolver.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/NodeTypeResolver.cs
@@ -79,10 +79,13 @@ namespace Ajuna.DotNet.Service.Node
 
       internal static NodeTypeName Array(NodeTypeResolver nodeTypeResolver, NodeTypeName nodeTypeName, uint length)
       {
-         var result = new NodeTypeName(nodeTypeResolver, NodeTypeNamespaceSource.Generated, nodeTypeName.BaseName, nodeTypeName.Arguments)
+
+
+         var result = new NodeTypeName(nodeTypeResolver, NodeTypeNamespaceSource.Generated, nodeTypeName.BaseName, null)
          {
             BaseNamePrefix = $"Arr{length}"
          };
+
          return result;
       }
 

--- a/Tools/Ajuna.DotNet/Service/Node/RestServiceControllerModuleBuilder.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/RestServiceControllerModuleBuilder.cs
@@ -12,13 +12,13 @@ namespace Ajuna.DotNet.Service.Node
    {
       private string NetApiProjectName { get; }
 
-      private RestServiceControllerModuleBuilder(string projectName, string netApiProjectName, uint id, PalletModule module, Dictionary<uint, (string, List<string>)> typeDict, Dictionary<uint, NodeType> nodeTypes) :
+      private RestServiceControllerModuleBuilder(string projectName, string netApiProjectName, uint id, PalletModule module, NodeTypeResolver typeDict, Dictionary<uint, NodeType> nodeTypes) :
           base(projectName, id, module, typeDict, nodeTypes)
       {
          NetApiProjectName = netApiProjectName;
       }
 
-      public static RestServiceControllerModuleBuilder Init(string projectName, string netApiProjectName, uint id, PalletModule module, Dictionary<uint, (string, List<string>)> typeDict, Dictionary<uint, NodeType> nodeTypes)
+      public static RestServiceControllerModuleBuilder Init(string projectName, string netApiProjectName, uint id, PalletModule module, NodeTypeResolver typeDict, Dictionary<uint, NodeType> nodeTypes)
       {
          return new RestServiceControllerModuleBuilder(projectName, netApiProjectName, id, module, typeDict, nodeTypes);
       }
@@ -105,8 +105,8 @@ namespace Ajuna.DotNet.Service.Node
                CodeExpression[] codeExpressions;
                if (entry.StorageType == Storage.Type.Plain)
                {
-                  (string, List<string>) fullItem = GetFullItemPath(entry.TypeMap.Item1);
-                  baseReturnType = new CodeTypeReference(fullItem.Item1);
+                  NodeTypeResolved fullItem = GetFullItemPath(entry.TypeMap.Item1);
+                  baseReturnType = new CodeTypeReference(fullItem.ToString());
                   parameterDeclaration = null;
                   codeExpressions = Array.Empty<CodeExpression>();
                }
@@ -114,9 +114,8 @@ namespace Ajuna.DotNet.Service.Node
                {
                   TypeMap typeMap = entry.TypeMap.Item2;
                   Storage.Hasher[] hashers = typeMap.Hashers;
-                  (string, List<string>) key = GetFullItemPath(typeMap.Key);
-                  (string, List<string>) value = GetFullItemPath(typeMap.Value);
-                  baseReturnType = new CodeTypeReference(value.Item1);
+                  NodeTypeResolved value = GetFullItemPath(typeMap.Value);
+                  baseReturnType = new CodeTypeReference(value.ToString());
                   parameterDeclaration = new CodeParameterDeclarationExpression(typeof(string), "key");
                   codeExpressions = new CodeExpression[] {
                                 new CodeVariableReferenceExpression(parameterDeclaration.Name)
@@ -155,7 +154,7 @@ namespace Ajuna.DotNet.Service.Node
                   getStorageMethod.CustomAttributes.Add(
                       new CodeAttributeDeclaration("StorageKeyBuilder",
                       new CodeAttributeArgument[] {
-                                new CodeAttributeArgument(new CodeTypeOfExpression($"{NetApiProjectName}.Generated.Model.{prefixName}{Module.Name}.{Module.Name}Storage")),
+                                new CodeAttributeArgument(new CodeTypeOfExpression($"{NetApiProjectName}.Generated.Storage.{Module.Name}Storage")),
                                 new CodeAttributeArgument(new CodePrimitiveExpression($"{entry.Name}Params"))
                       }));
                }
@@ -166,9 +165,9 @@ namespace Ajuna.DotNet.Service.Node
                   getStorageMethod.CustomAttributes.Add(
                       new CodeAttributeDeclaration("StorageKeyBuilder",
                       new CodeAttributeArgument[] {
-                                new CodeAttributeArgument(new CodeTypeOfExpression($"{NetApiProjectName}.Generated.Model.{prefixName}{Module.Name}.{Module.Name}Storage")),
+                                new CodeAttributeArgument(new CodeTypeOfExpression($"{NetApiProjectName}.Generated.Storage.{Module.Name}Storage")),
                                 new CodeAttributeArgument(new CodePrimitiveExpression($"{entry.Name}Params")),
-                                new CodeAttributeArgument(new CodeTypeOfExpression(GetFullItemPath(entry.TypeMap.Item2.Key).Item1))
+                                new CodeAttributeArgument(new CodeTypeOfExpression(GetFullItemPath(entry.TypeMap.Item2.Key).ToString()))
                       }));
                }
                else

--- a/Tools/Ajuna.DotNet/Service/Node/RestServiceStorageModuleBuilder.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/RestServiceStorageModuleBuilder.cs
@@ -11,12 +11,12 @@ namespace Ajuna.DotNet.Service.Node
 {
    public class RestServiceStorageModuleBuilder : ModuleBuilderBase
    {
-      private RestServiceStorageModuleBuilder(string projectName, uint id, PalletModule module, Dictionary<uint, (string, List<string>)> typeDict, Dictionary<uint, NodeType> nodeTypes) :
+      private RestServiceStorageModuleBuilder(string projectName, uint id, PalletModule module, NodeTypeResolver typeDict, Dictionary<uint, NodeType> nodeTypes) :
           base(projectName, id, module, typeDict, nodeTypes)
       {
       }
 
-      public static RestServiceStorageModuleBuilder Init(string projectName, uint id, PalletModule module, Dictionary<uint, (string, List<string>)> typeDict, Dictionary<uint, NodeType> nodeTypes)
+      public static RestServiceStorageModuleBuilder Init(string projectName, uint id, PalletModule module, NodeTypeResolver typeDict, Dictionary<uint, NodeType> nodeTypes)
       {
          return new RestServiceStorageModuleBuilder(projectName, id, module, typeDict, nodeTypes);
       }
@@ -106,9 +106,9 @@ namespace Ajuna.DotNet.Service.Node
                CodeExpression[] updateExpression, tryGetExpression;
                if (entry.StorageType == Storage.Type.Plain)
                {
-                  (string, List<string>) fullItem = GetFullItemPath(entry.TypeMap.Item1);
-                  baseReturnType = new CodeTypeReference(fullItem.Item1);
-                  returnType = new CodeTypeReference($"TypedStorage<{fullItem.Item1}>");
+                  NodeTypeResolved fullItem = GetFullItemPath(entry.TypeMap.Item1);
+                  baseReturnType = new CodeTypeReference(fullItem.ToString());
+                  returnType = new CodeTypeReference($"TypedStorage<{fullItem.ToString()}>");
 
                   updateExpression = new CodeExpression[] {
                                             new CodeVariableReferenceExpression(dataParamter.Name)};
@@ -118,10 +118,10 @@ namespace Ajuna.DotNet.Service.Node
                {
                   TypeMap typeMap = entry.TypeMap.Item2;
                   Storage.Hasher[] hashers = typeMap.Hashers;
-                  (string, List<string>) key = GetFullItemPath(typeMap.Key);
-                  (string, List<string>) value = GetFullItemPath(typeMap.Value);
-                  baseReturnType = new CodeTypeReference(value.Item1);
-                  returnType = new CodeTypeReference($"TypedMapStorage<{value.Item1}>");
+                  NodeTypeResolved key = GetFullItemPath(typeMap.Key);
+                  NodeTypeResolved value = GetFullItemPath(typeMap.Value);
+                  baseReturnType = new CodeTypeReference(value.ToString());
+                  returnType = new CodeTypeReference($"TypedMapStorage<{value.ToString()}>");
 
                   updateExpression = new CodeExpression[] {
                                 new CodeVariableReferenceExpression(keyParamter.Name),

--- a/Tools/Ajuna.DotNet/Service/Node/RunetimeBuilder.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/RunetimeBuilder.cs
@@ -9,12 +9,12 @@ namespace Ajuna.DotNet.Service.Node
 {
    public class RunetimeBuilder : TypeBuilderBase
    {
-      private RunetimeBuilder(string projectName, uint id, NodeTypeVariant typeDef, Dictionary<uint, (string, List<string>)> typeDict)
+      private RunetimeBuilder(string projectName, uint id, NodeTypeVariant typeDef, NodeTypeResolver typeDict)
           : base(projectName, id, typeDef, typeDict)
       {
       }
 
-      public static RunetimeBuilder Init(string projectName, uint id, NodeTypeVariant typeDef, Dictionary<uint, (string, List<string>)> typeDict)
+      public static RunetimeBuilder Init(string projectName, uint id, NodeTypeVariant typeDef, NodeTypeResolver typeDict)
       {
          return new RunetimeBuilder(projectName, id, typeDef, typeDict);
       }
@@ -24,7 +24,7 @@ namespace Ajuna.DotNet.Service.Node
          var typeDef = TypeDef as NodeTypeVariant;
 
          string runtimeType = $"{typeDef.Path.Last()}";
-         string enumName = $"Node{runtimeType}";
+         string enumName = runtimeType;
 
          ClassName = $"Enum{enumName}";
          ReferenzName = $"{NamespaceName}.{ClassName}";

--- a/Tools/Ajuna.DotNet/Service/Node/StructBuilder.cs
+++ b/Tools/Ajuna.DotNet/Service/Node/StructBuilder.cs
@@ -10,7 +10,7 @@ namespace Ajuna.DotNet.Service.Node
 {
    public class StructBuilder : TypeBuilderBase
    {
-      private StructBuilder(string projectName, uint id, NodeTypeComposite typeDef, Dictionary<uint, (string, List<string>)> typeDict)
+      private StructBuilder(string projectName, uint id, NodeTypeComposite typeDef, NodeTypeResolver typeDict)
           : base(projectName, id, typeDef, typeDict)
       {
       }
@@ -71,9 +71,9 @@ namespace Ajuna.DotNet.Service.Node
                NodeTypeField typeField = typeFields[i];
 
                string fieldName = StructBuilder.GetFieldName(typeField, "value", typeFields.Length, i);
-               (string, List<string>) fullItem = GetFullItemPath(typeField.TypeId);
+               NodeTypeResolved fullItem = GetFullItemPath(typeField.TypeId);
 
-               decodeMethod.Statements.Add(new CodeSnippetExpression($"{fieldName.MakeMethod()} = new {fullItem.Item1}()"));
+               decodeMethod.Statements.Add(new CodeSnippetExpression($"{fieldName.MakeMethod()} = new {fullItem.ToString()}()"));
                decodeMethod.Statements.Add(new CodeSnippetExpression($"{fieldName.MakeMethod()}.Decode(byteArray, ref p)"));
             }
          }
@@ -107,7 +107,7 @@ namespace Ajuna.DotNet.Service.Node
          return encodeMethod;
       }
 
-      public static BuilderBase Init(string projectName, uint id, NodeTypeComposite typeDef, Dictionary<uint, (string, List<string>)> typeDict)
+      public static BuilderBase Init(string projectName, uint id, NodeTypeComposite typeDef, NodeTypeResolver typeDict)
       {
          return new StructBuilder(projectName, id, typeDef, typeDict);
       }
@@ -147,9 +147,9 @@ namespace Ajuna.DotNet.Service.Node
                NodeTypeField typeField = typeDef.TypeFields[i];
                string fieldName = StructBuilder.GetFieldName(typeField, "value", typeDef.TypeFields.Length, i);
 
-               (string, List<string>) fullItem = GetFullItemPath(typeField.TypeId);
+               NodeTypeResolved fullItem = GetFullItemPath(typeField.TypeId);
 
-               CodeMemberField field = StructBuilder.GetPropertyField(fieldName, fullItem.Item1);
+               CodeMemberField field = StructBuilder.GetPropertyField(fieldName, fullItem.ToString());
 
                // add comment to field if exists
                field.Comments.AddRange(GetComments(typeField.Docs, null, fieldName));

--- a/Version.props
+++ b/Version.props
@@ -4,10 +4,10 @@
       <!-- Configuration -->
       <VersionMajor>0</VersionMajor>
       <VersionMinor>1</VersionMinor>
-      <VersionPatch>21</VersionPatch>
+      <VersionPatch>22</VersionPatch>
       <AssemblyVersion>$(VersionMajor).$(VersionMinor).$(VersionPatch)</AssemblyVersion>
 
-      <AjunaPackageVersion>0.1.21</AjunaPackageVersion>
+      <AjunaPackageVersion>0.1.22</AjunaPackageVersion>
 
       <!-- Variables -->
       <AjunaVersion>$(AssemblyVersion)</AjunaVersion>

--- a/Version.props
+++ b/Version.props
@@ -4,10 +4,10 @@
       <!-- Configuration -->
       <VersionMajor>0</VersionMajor>
       <VersionMinor>1</VersionMinor>
-      <VersionPatch>22</VersionPatch>
+      <VersionPatch>23</VersionPatch>
       <AssemblyVersion>$(VersionMajor).$(VersionMinor).$(VersionPatch)</AssemblyVersion>
 
-      <AjunaPackageVersion>0.1.22</AjunaPackageVersion>
+      <AjunaPackageVersion>0.1.23</AjunaPackageVersion>
 
       <!-- Variables -->
       <AjunaVersion>$(AssemblyVersion)</AjunaVersion>


### PR DESCRIPTION
This PR brings (again) recursive type generation as discussed with @darkfriend77 . It also forces us to generate the original namespace names during rundown; ensuring that we're not conflicting in names anymore.

The initial PR was reverted because it brought issues with some nested types that are fixed in this second attempt. Also event and call generation seem to work just fine now.

This build was tested with the following nodes:

wss://rpc.polkadot.io
wss://rpc-parachain.bajun.network
and default substrate and node-template runtimes.

The official Polkadot RPC uses some types that have never been used before and these cause some Encoding() / Decoding() issues. But since that is out of scope of this PR - here we go.